### PR TITLE
export HasSpock(SpockState,...) to be able to write type signatures

### DIFF
--- a/src/Web/Spock.hs
+++ b/src/Web/Spock.hs
@@ -22,7 +22,7 @@ module Web.Spock
       -- * Database
     , PoolOrConn (..), ConnBuilder (..), PoolCfg (..)
       -- * Accessing Database and State
-    , HasSpock (runQuery, getState)
+    , HasSpock (SpockState, SpockConn, SpockSession, runQuery, getState)
       -- * Sessions
     , SessionCfg (..)
     , readSession, writeSession, modifySession, clearAllSessions


### PR DESCRIPTION
Currently it's impossible to write the type signature of runQuery or getState in a program using spock because the associated types are not exported.
