### PR TITLE
Make ResponseBody more generic; add stream responses

### DIFF
--- a/src/Web/Spock/Shared.hs
+++ b/src/Web/Spock/Shared.hs
@@ -20,7 +20,7 @@ module Web.Spock.Shared
     , params, param, param'
      -- * Sending responses
     , setStatus, setHeader, redirect, jumpNext, setCookie, setCookie', bytes, lazyBytes
-    , text, html, file, json
+    , text, html, file, json, stream, response
       -- * Middleware helpers
     , middlewarePass, modifyVault, queryVault
       -- * Database


### PR DESCRIPTION
Fixes #18.  `ResponseBody` is now just the (Wai) function that will be used to generate the response, of a similar shape to `Wai.response*` functions.  Added `stream` and `response` functions.