### PR TITLE
Use Control.Monad.Except. Error is deprecated.

### DIFF
--- a/src/Web/Spock/Internal/Core.hs
+++ b/src/Web/Spock/Internal/Core.hs
@@ -18,7 +18,7 @@ import Web.Spock.Internal.SessionManager
 import Web.Spock.Internal.Types
 import Web.Spock.Internal.Wire
 
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Resource
 import Data.Pool

--- a/src/Web/Spock/Internal/CoreAction.hs
+++ b/src/Web/Spock/Internal/CoreAction.hs
@@ -19,7 +19,7 @@ import Web.Spock.Internal.Wire
 
 import Control.Arrow (first)
 import Control.Monad
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State hiding (get, put)
 import Data.Monoid


### PR DESCRIPTION
Monad.Control.Error is deprecated. 
Please see the this page.
http://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-Error.html