### PR TITLE
Use Control.Monad.Except

### DIFF
--- a/Spock.cabal
+++ b/Spock.cabal
@@ -39,7 +39,7 @@ library
                        hashable >=1.2,
                        http-types >=0.8,
                        monad-control >=0.3,
-                       mtl >=2.1,
+                       mtl >=2.2.1,
                        old-locale >=1.0,
                        path-pieces >=0.1.4,
                        random >=1.0,

--- a/src/Web/Spock/Internal/Core.hs
+++ b/src/Web/Spock/Internal/Core.hs
@@ -18,7 +18,7 @@ import Web.Spock.Internal.SessionManager
 import Web.Spock.Internal.Types
 import Web.Spock.Internal.Wire
 
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Monad.Trans.Reader
 import Control.Monad.Trans.Resource
 import Data.Pool

--- a/src/Web/Spock/Internal/CoreAction.hs
+++ b/src/Web/Spock/Internal/CoreAction.hs
@@ -19,7 +19,7 @@ import Web.Spock.Internal.Wire
 
 import Control.Arrow (first)
 import Control.Monad
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State hiding (get, put)
 import Data.Monoid


### PR DESCRIPTION
Monad.Control.Error is deprecated.
Please see the this page.
http://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-Error.html