### PR TITLE
migrate to ghc 7.10 by handling time > 1.5.0

### DIFF
--- a/src/Web/Spock/Internal/CoreAction.hs
+++ b/src/Web/Spock/Internal/CoreAction.hs
@@ -32,7 +32,11 @@ import Data.Time
 import Network.HTTP.Types.Header (ResponseHeaders)
 import Network.HTTP.Types.Status
 import Prelude hiding (head)
-import System.Locale
+#if MIN_VERSION_time(1,5,0)
+import Data.Time.Format (defaultTimeLocale)
+#else
+import System.Locale (defaultTimeLocale)
+#endif
 import Web.PathPieces
 import Web.Routing.AbstractRouter
 import qualified Data.Aeson as A

--- a/src/Web/Spock/Internal/SessionManager.hs
+++ b/src/Web/Spock/Internal/SessionManager.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts, DeriveGeneric, OverloadedStrings, DoAndIfThenElse, RankNTypes #-}
 module Web.Spock.Internal.SessionManager
     ( createSessionManager
@@ -16,7 +17,11 @@ import Control.Monad
 import Control.Monad.Trans
 import Data.List (foldl')
 import Data.Time
-import System.Locale
+#if MIN_VERSION_time(1,5,0)
+import Data.Time.Format (defaultTimeLocale)
+#else
+import System.Locale (defaultTimeLocale)
+#endif
 import System.Random
 import qualified Data.ByteString.Base64.URL as B64
 import qualified Data.ByteString.Char8 as BSC


### PR DESCRIPTION
this uses the trick described in the migration guide for 7.10.1 (https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10)