### PR TITLE
Update blog post on type-safe routing

### DIFF
--- a/_posts/2015-04-19-type-safe_routing.markdown
+++ b/_posts/2015-04-19-type-safe_routing.markdown
@@ -122,10 +122,8 @@ HVectElim '[a,b,c,d] x ≡ a -> (b -> (c -> (d -> x)))
 Finally, routes can be serialized with
 
 {% highlight haskell %}
-renderRoute :: HasRep as => Path as -> HVectElim as Text
+renderRoute :: Path as -> HVectElim as Text
 {% endhighlight %}
-
-The `HasRep as` constraint is an implementation detail and can be ignored.
 
 Internally, all route handlers are stored in a tree-like structure which can be efficiently queried for matches.
 


### PR DESCRIPTION
'renderRoute :: Path as -> HVectElim as -> Text' doesn't have the 'HasRep as' constraint anymore