### PR TITLE
Richer options for setting cookies

### DIFF
--- a/Spock.cabal
+++ b/Spock.cabal
@@ -74,6 +74,7 @@ library
                        resourcet >= 0.4,
                        stm >=2.4,
                        stm-containers >=0.2,
+                       string-conversions >=0.4,
                        text >= 0.11.3.1,
                        time >=1.4,
                        transformers >=0.3,

--- a/Spock.cabal
+++ b/Spock.cabal
@@ -74,7 +74,6 @@ library
                        resourcet >= 0.4,
                        stm >=2.4,
                        stm-containers >=0.2,
-                       string-conversions >=0.4,
                        text >= 0.11.3.1,
                        time >=1.4,
                        transformers >=0.3,

--- a/src/Web/Spock/Internal/Cookies.hs
+++ b/src/Web/Spock/Internal/Cookies.hs
@@ -24,7 +24,7 @@ import           System.Locale           (defaultTimeLocale)
 
 data CookieSettings = CookieSettings { cs_EOL      :: CookieEOL
                                      , cs_path     :: BS.ByteString
-                                     , cs_domain   :: BS.ByteString
+                                     , cs_domain   :: Maybe BS.ByteString
                                      , cs_HTTPOnly :: Bool
                                      , cs_secure   :: Bool
                                      }
@@ -37,7 +37,7 @@ defaultCookieSettings :: CookieSettings
 defaultCookieSettings = CookieSettings { cs_EOL      = CookieValidForSession
                                        , cs_HTTPOnly = False
                                        , cs_secure   = False
-                                       , cs_domain   = BS.empty
+                                       , cs_domain   = Nothing
                                        , cs_path     = "/"
                                        }
 
@@ -54,7 +54,9 @@ generateCookieHeaderString name value CookieSettings{..} now =
   where
       nv       = BS.concat [T.encodeUtf8 name, "=", urlEncode value]
       path     = BS.concat ["path=", cs_path]
-      domain   = if BS.null cs_domain then BS.empty else BS.concat ["domain=", cs_domain]
+      domain   = case cs_domain of
+                    Nothing -> BS.empty
+                    Just d  -> BS.concat ["domain=", d]
       httpOnly = if cs_HTTPOnly then "HttpOnly" else BS.empty
       secure   = if cs_secure then "Secure" else BS.empty
 

--- a/src/Web/Spock/Internal/Cookies.hs
+++ b/src/Web/Spock/Internal/Cookies.hs
@@ -22,26 +22,55 @@ import qualified Network.HTTP.Types.URI  as URI (urlEncode, urlDecode)
 import           System.Locale           (defaultTimeLocale)
 #endif
 
-data CookieSettings = CookieSettings { cs_EOL      :: CookieEOL
-                                     , cs_path     :: BS.ByteString
-                                     , cs_domain   :: Maybe BS.ByteString
-                                     , cs_HTTPOnly :: Bool
-                                     , cs_secure   :: Bool
-                                     }
+-- | Cookie settings
+data CookieSettings
+   = CookieSettings
+   { cs_EOL      :: CookieEOL
+     -- ^ cookie expiration setting, see 'CookieEOL'
+   , cs_path     :: BS.ByteString
+     -- ^ a path for the cookie
+   , cs_domain   :: Maybe BS.ByteString
+     -- ^ a domain for the cookie. 'Nothing' means no domain is set
+   , cs_HTTPOnly :: Bool
+     -- ^ whether the cookie should be set as HttpOnly
+   , cs_secure   :: Bool
+     -- ^ whether the cookie should be marked secure (sent over HTTPS only)
+   }
 
-data CookieEOL = CookieValidUntil UTCTime
-               | CookieValidFor NominalDiffTime
-               | CookieValidForSession
+-- | Setting cookie expiration
+data CookieEOL
+   = CookieValidUntil UTCTime
+   -- ^ a point in time in UTC until the cookie is valid
+   | CookieValidFor NominalDiffTime
+   -- ^ a period (in seconds) for which the cookie is valid
+   | CookieValidForSession
+   -- ^ the cookie expires with the browser session
 
+-- | Default cookie settings, equals
+--
+-- > CookieSettings
+-- >   { cs_EOL      = CookieValidForSession
+-- >   , cs_HTTPOnly = False
+-- >   , cs_secure   = False
+-- >   , cs_domain   = Nothing
+-- >   , cs_path     = "/"
+-- >   }
+--
 defaultCookieSettings :: CookieSettings
-defaultCookieSettings = CookieSettings { cs_EOL      = CookieValidForSession
-                                       , cs_HTTPOnly = False
-                                       , cs_secure   = False
-                                       , cs_domain   = Nothing
-                                       , cs_path     = "/"
-                                       }
+defaultCookieSettings =
+    CookieSettings
+    { cs_EOL      = CookieValidForSession
+    , cs_HTTPOnly = False
+    , cs_secure   = False
+    , cs_domain   = Nothing
+    , cs_path     = "/"
+    }
 
-generateCookieHeaderString :: T.Text -> T.Text -> CookieSettings -> UTCTime -> BS.ByteString
+generateCookieHeaderString :: T.Text
+                           -> T.Text
+                           -> CookieSettings
+                           -> UTCTime
+                           -> BS.ByteString
 generateCookieHeaderString name value CookieSettings{..} now =
     BS.intercalate "; " $ filter (not . BS.null) [ nv
                                                  , domain

--- a/src/Web/Spock/Internal/CoreAction.hs
+++ b/src/Web/Spock/Internal/CoreAction.hs
@@ -74,11 +74,7 @@ rawHeader t =
 cookie :: MonadIO m => T.Text -> ActionCtxT ctx m (Maybe T.Text)
 cookie name =
     do req <- request
-       return $ lookup "cookie" (Wai.requestHeaders req) >>= lookup name . parseCookies . T.decodeUtf8
-    where
-      parseCookies :: T.Text -> [(T.Text, T.Text)]
-      parseCookies = map parseCookie . T.splitOn ";" . T.concat . T.words
-      parseCookie = first T.init . T.breakOnEnd "="
+       return $ lookup "cookie" (Wai.requestHeaders req) >>= lookup name . parseCookies
 {-# INLINE cookie #-}
 
 -- | Tries to dected the preferred format of the response using the Accept header

--- a/src/Web/Spock/Internal/CoreAction.hs
+++ b/src/Web/Spock/Internal/CoreAction.hs
@@ -70,7 +70,7 @@ rawHeader t =
     liftM (lookup t . Wai.requestHeaders) request
 {-# INLINE rawHeader #-}
 
--- | Read a cookie
+-- | Read a cookie. The cookie value will already be urldecoded.
 cookie :: MonadIO m => T.Text -> ActionCtxT ctx m (Maybe T.Text)
 cookie name =
     do req <- request
@@ -355,6 +355,7 @@ runInContext newCtx action =
          Right d -> return d
 {-# INLINE runInContext #-}
 
+-- | Set a cookie. The cookie value will be urlencoded.
 setCookie :: MonadIO m => T.Text -> T.Text -> CookieSettings -> ActionCtxT ctx m ()
 setCookie name value cs =
     do now <- liftIO getCurrentTime
@@ -362,6 +363,7 @@ setCookie name value cs =
        setRawMultiHeader MultiHeaderSetCookie cookieHeaderString
 {-# INLINE setCookie #-}
 
+-- | Delete a cookie
 deleteCookie :: MonadIO m => T.Text -> ActionCtxT ctx m ()
 deleteCookie name = setCookie name T.empty cs
   where

--- a/test/Web/Spock/Internal/CookiesSpec.hs
+++ b/test/Web/Spock/Internal/CookiesSpec.hs
@@ -59,7 +59,7 @@ spec =
 
            describe "when setting the domain" $
                it "should generate the correct domain pair" $
-                   g "foo" "bar" def { cs_domain = "example.org" } `shouldContainOnce` "domain=example.org"
+                   g "foo" "bar" def { cs_domain = Just "example.org" } `shouldContainOnce` "domain=example.org"
 
            describe "when setting the httponly option" $
                it "should generate the httponly key" $

--- a/test/Web/Spock/Internal/CookiesSpec.hs
+++ b/test/Web/Spock/Internal/CookiesSpec.hs
@@ -3,7 +3,7 @@
 module Web.Spock.Internal.CookiesSpec (spec) where
 
 import Test.Hspec
-import qualified Data.Text as T
+import qualified Data.ByteString as BS
 import Data.Time
 
 import Web.Spock.Internal.Cookies
@@ -30,10 +30,10 @@ spec =
                    generated `shouldNotContain'` "domain="
 
                it "should not generate a httponly key" $
-                   T.toLower generated `shouldNotContain'` "httponly"
+                   generated `shouldNotContain'` "HttpOnly"
 
                it "should not generate a secure key" $
-                   T.toLower generated `shouldNotContain'` "secure"
+                   generated `shouldNotContain'` "Secure"
 
            describe "when setting an expiration time in the future" $
             do let generated = g "foo" "bar" def { cs_EOL = CookieValidUntil (UTCTime (fromGregorian 2016 1 1) 0) }
@@ -89,6 +89,6 @@ spec =
       def      = defaultCookieSettings
       t        = UTCTime (fromGregorian 2015 9 1) (21*60*60)
 
-      shouldContainOnce haystack needle = T.count needle haystack `shouldBe` 1
-      shouldNotContain' haystack needle = T.count needle haystack `shouldBe` 0
+      shouldContainOnce haystack needle = snd (BS.breakSubstring needle haystack) `shouldNotBe` BS.empty
+      shouldNotContain' haystack needle = snd (BS.breakSubstring needle haystack) `shouldBe` BS.empty
 

--- a/test/Web/Spock/Internal/CookiesSpec.hs
+++ b/test/Web/Spock/Internal/CookiesSpec.hs
@@ -10,7 +10,7 @@ import Web.Spock.Internal.Cookies
 
 spec :: Spec
 spec =
-    describe "Generating Cookies" $
+    do describe "Generating Cookies" $
         do describe "with the default settings" $
             do let generated = g "foo" "bar" def
 
@@ -67,7 +67,22 @@ spec =
 
            describe "when setting the secure option" $
                it "should generate the secure key" $
-                   g "foo" "bar" def { cs_secure = True } `shouldContainOnce` "secure"
+                   g "foo" "bar" def { cs_secure = True } `shouldContainOnce` "Secure"
+
+           describe "cookie value" $
+               it "should be urlencoded" $
+                   g "foo" "most+special chars;%бисквитки" def `shouldContainOnce`
+                     "foo=most%2Bspecial%20chars%3B%25%D0%B1%D0%B8%D1%81%D0%BA%D0%B2%D0%B8%D1%82%D0%BA%D0%B8"
+
+       describe "Parsing cookies" $
+           do it "should parse urlencoded multiple cookies" $
+                  parseCookies "foo=bar;quux=h&m" `shouldBe` [("foo", "bar"), ("quux", "h&m")]
+
+              it "should parse urlencoded values" $
+                 parseCookies "foo=most%2Bspecial%20chars%3B%25" `shouldBe` [("foo", "most+special chars;%")]
+
+              it "should parse urlencoded utf-8 content" $
+                 parseCookies "foo=%D0%B1%D0%B8%D1%81%D0%BA%D0%B2%D0%B8%D1%82%D0%BA%D0%B8" `shouldBe` [("foo", "бисквитки")]
 
   where
       g n v cs = generateCookieHeaderString n v cs t


### PR DESCRIPTION
This PR contains the following public facing changes:
- cookie values are urlencoded when setting and urldecoded when reading
- adds functions for setting raw (ByteString) headers 