### PR TITLE
Return 400 when unable to parse json body

### DIFF
--- a/src/Web/Spock/Internal/CoreAction.hs
+++ b/src/Web/Spock/Internal/CoreAction.hs
@@ -113,13 +113,13 @@ jsonBody =
        return $ A.decodeStrict b
 {-# INLINE jsonBody #-}
 
--- | Parse the request body as json and fails with 500 status code on error
+-- | Parse the request body as json and fails with 400 status code on error
 jsonBody' :: (MonadIO m, A.FromJSON a) => ActionCtxT ctx m a
 jsonBody' =
     do b <- body
        case A.eitherDecodeStrict' b of
          Left err ->
-             do setStatus status500
+             do setStatus status400
                 text (T.pack $ "Failed to parse json: " ++ err)
          Right val ->
              return val


### PR DESCRIPTION
500 should be returned when a server encounters an unexpected error while handling a request. Not being able to parse JSON to a certain type is not an unexpected error IMO. It is most likely an error in the request sent from the client. Thus this PR changed `jsonBody'` so that it returns "400 - Bad Request" when parsing a body fails.

What do you think? If you like this I can do a PR that does the same thing for `param'`?