### PR TITLE
Derive Show for UploadedFile

### DIFF
--- a/Spock-core/src/Web/Spock/Internal/Wire.hs
+++ b/Spock-core/src/Web/Spock/Internal/Wire.hs
@@ -74,7 +74,7 @@ data UploadedFile
    { uf_name :: !T.Text
    , uf_contentType :: !T.Text
    , uf_tempLocation :: !FilePath
-   }
+   } deriving Show
 
 data VaultIf
    = VaultIf


### PR DESCRIPTION
This PR derives `Show` for `UploadedFile`.

This can help with debugging or exploratory programming.  When using the
[`files`](https://hackage.haskell.org/package/Spock-core-0.11.0.0/docs/Web-Spock-Action.html#v:files)
function for the first time, it is convenient to be able to try
`show`ing the `HashMap Text UploadedFile`.  However, there needs to be a
`Show` instance for `UploadedFile` for this to be possible.

Of course, it doesn't make sense to use this `Show` instance in a
production application.