### PR TITLE
Bump Spock-core dependency

### DIFF
--- a/Spock/Spock.cabal
+++ b/Spock/Spock.cabal
@@ -45,7 +45,7 @@ library
                 Web.Spock.Internal.Monad,
                 Web.Spock.Internal.Types
   build-depends:
-                       Spock-core >= 0.11,
+                       Spock-core >= 0.12,
                        base >= 4 && < 5,
                        base64-bytestring >=1.0,
                        bytestring >=0.10,


### PR DESCRIPTION
Spock doesn't compile with Spock-core-0.11:

```
Configuring Spock-0.12.0.0...
Building Spock-0.12.0.0...
Preprocessing library Spock-0.12.0.0...
[1 of 7] Compiling Web.Spock.Internal.Types ( src/Web/Spock/Internal/Types.hs, dist/build/Web/Spock/Internal/Types.o )
[2 of 7] Compiling Web.Spock.Internal.SessionVault ( src/Web/Spock/Internal/SessionVault.hs, dist/build/Web/Spock/Internal/SessionVault.o )
[3 of 7] Compiling Web.Spock.Config ( src/Web/Spock/Config.hs, dist/build/Web/Spock/Config.o )
[4 of 7] Compiling Web.Spock.Internal.SessionManager ( src/Web/Spock/Internal/SessionManager.hs, dist/build/Web/Spock/Internal/SessionManager.o )
[5 of 7] Compiling Web.Spock.Internal.Monad ( src/Web/Spock/Internal/Monad.hs, dist/build/Web/Spock/Internal/Monad.o )
[6 of 7] Compiling Web.Spock.SessionActions ( src/Web/Spock/SessionActions.hs, dist/build/Web/Spock/SessionActions.o )
[7 of 7] Compiling Web.Spock        ( src/Web/Spock.hs, dist/build/Web/Spock.o )

src/Web/Spock.hs:14:45: Not in scope: ‘wildcard’
```