### PR TITLE
Add instance of MonadTransControl, MonadBase, and MonadBaseControl for ActionCtxT

### DIFF
--- a/Spock-core/Spock-core.cabal
+++ b/Spock-core/Spock-core.cabal
@@ -41,6 +41,7 @@ library
                        hashable >=1.2,
                        http-types >=0.8,
                        hvect >= 0.4,
+                       monad-control >= 1.0,
                        mtl >=2.1,
                        http-api-data >= 0.2,
                        old-locale >=1.0,

--- a/Spock-core/Spock-core.cabal
+++ b/Spock-core/Spock-core.cabal
@@ -77,11 +77,13 @@ test-suite spockcoretests
                        hspec >= 2.0,
                        hspec-wai >= 0.6,
                        http-types,
+                       monad-control,
                        Spock-core,
                        reroute,
                        text,
                        time,
                        transformers >=0.3,
+                       transformers-base,
                        unordered-containers,
                        wai
 

--- a/Spock-core/Spock-core.cabal
+++ b/Spock-core/Spock-core.cabal
@@ -52,6 +52,7 @@ library
                        text >= 0.11.3.1,
                        time >=1.4,
                        transformers >=0.3,
+                       transformers-base >=0.4,
                        unordered-containers >=0.2,
                        vault >=0.3,
                        wai >=3.0,

--- a/Spock-core/test/Web/Spock/SafeSpec.hs
+++ b/Spock-core/test/Web/Spock/SafeSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DoAndIfThenElse #-}
@@ -9,11 +10,15 @@ import Web.Spock.FrameworkSpecHelper
 
 import Control.Exception.Base
 import Control.Monad
+import Control.Monad.Base
+import Control.Monad.Trans.Control
+import Control.Monad.Trans.Reader
 import Data.Aeson
 import Data.Monoid
 import GHC.Generics
 import Network.HTTP.Types.Status
 import Test.Hspec
+import qualified Control.Exception as Exception
 import qualified Data.ByteString.Lazy.Char8 as BSLC
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -112,6 +117,44 @@ routeRenderingSpec =
              let r3 = "blog" <//> (var :: Var Int) <//> (var :: Var T.Text)
              renderRoute r3 2 "BIIM" `shouldBe` "/blog/2/BIIM"
 
+data InstancesTestException = InstancesTestException deriving Show
+instance Exception InstancesTestException
+
+instancesApp :: SpockCtxT () (ReaderT T.Text IO) ()
+instancesApp =
+    do get ("instances" <//> "monad-base") $ text =<< liftBase (pure "ok")
+       get ("instances" <//> "monad-base-control") $
+           do res <-
+                  catch'
+                      (throwIO' InstancesTestException)
+                      (\(_ :: InstancesTestException) -> pure "ok")
+              text res
+       get ("instances" <//> "monad-trans-control") $
+           do res <- liftWith (\run -> ask >>= run . text)
+              restoreT $ pure res
+    where
+      -- This is 'catch' from 'Control.Exception.Lifted'.
+      catch' :: (MonadBaseControl IO m, Exception e) => m a -> (e -> m a) -> m a
+      catch' a handler =
+        control $ \runInIO ->
+           Exception.catch (runInIO a) (\e -> runInIO $ handler e)
+
+      -- This is 'throwIO' from 'Control.Exception.Lifted'.
+      throwIO' :: (MonadBase IO m, Exception e) => e -> m a
+      throwIO' = liftBase . Exception.throwIO
+
+
+instancesSpec :: Spec
+instancesSpec =
+    describe "Instances for ActionT are correct" $
+    Test.with (spockAsApp $ spockT (flip runReaderT "ok") instancesApp) $
+        do it "MonadBase" $
+              Test.request "GET" "/instances/monad-base" [] "" `Test.shouldRespondWith` "ok"
+           it "MonadBaseControl" $
+              Test.request "GET" "/instances/monad-base-control" [] "" `Test.shouldRespondWith` "ok"
+           it "MonadTransControl" $
+              Test.request "GET" "/instances/monad-trans-control" [] "" `Test.shouldRespondWith` "ok"
+
 ctxApp :: SpockT IO ()
 ctxApp =
     prehook hook $
@@ -138,6 +181,7 @@ spec =
     describe "SafeRouting" $
     do frameworkSpec (spockAsApp $ spockT id app)
        ctxSpec
+       instancesSpec
        routeRenderingSpec
        sizeLimitSpec $ \lim -> spockAsApp $ spockConfigT (defaultSpockConfig { sc_maxRequestSize = Just lim }) id $
           post "size" $ body >>= bytes


### PR DESCRIPTION
This PR adds an instance of `MonadTransControl`, `MonadBase`, and `MonadBaseControl` for `ActionCtxT`.  This closes #116.

Commit 0aa24d4 adds an instance of `MonadTransControl` for `ActionCtxT`.  Aside from some hairy wrapping and unwrapping, it is pretty straight-forward.

Commit 9d83386 adds an instance of `MonadBase` and `MonadBaseControl` for `ActionCtxT`.  The main problem with this is that it requires `UndecidableInstances`.

Here are three different courses of action I feel like we could take:

1.  Just merge in this PR.  `monad-control` and `transformers-base` both use `UndeciableInstances` when [defining](https://github.com/basvandijk/monad-control/blob/4a3ec0631dda597b1b13d1a6a756d3b651f511b4/Control/Monad/Trans/Control.hs#L7) their [instances](https://github.com/mvv/transformers-base/blob/f4be15d64ff997770b4fdcd967dd5bd9498614e7/src/Control/Monad/Base.hs#L6) of `MonadBase` and `MonadBaseControl` for the standard transformers like `ExceptT`, `ReaderT`, etc.  If it's good enough for them, it's good enough for us.

    Realistically, it's unlikely that a user would want to define an alternative instance of `MonadBase` or `MonadBaseControl` for `ActionCtxT`.

2.  Right now, the `MonadBase` and `MonadBaseControl` instances look like this:

    ```haskell
    instance MonadBase b m => MonadBase b (ActionCtxT ctx m) where
        liftBase = liftBaseDefault

    instance MonadBaseControl b m => MonadBaseControl b (ActionCtxT ctx m) where
        type StM (ActionCtxT ctx m) a = ComposeSt (ActionCtxT ctx) m a
        liftBaseWith = defaultLiftBaseWith
        restoreM = defaultRestoreM
    ```

    Trying to compile this without `UndecidableInstances` produces the following warning:

    ```
    /home/illabout/git/spock/Spock-core/src/Web/Spock/Internal/Wire.hs:275:10: error:
        • Illegal instance declaration for ‘MonadBase b (ActionCtxT ctx m)’
            The coverage condition fails in class ‘MonadBase’
              for functional dependency: ‘m -> b’
            Reason: lhs type ‘ActionCtxT ctx m’ does not determine rhs type ‘b’
            Un-determined variable: b
            Using UndecidableInstances might help
        • In the instance declaration for ‘MonadBase b (ActionCtxT ctx m)’

    /home/illabout/git/spock/Spock-core/src/Web/Spock/Internal/Wire.hs:278:10: error:
        • Illegal instance declaration for
            ‘MonadBaseControl b (ActionCtxT ctx m)’
            The coverage condition fails in class ‘MonadBaseControl’
              for functional dependency: ‘m -> b’
            Reason: lhs type ‘ActionCtxT ctx m’ does not determine rhs type ‘b’
            Un-determined variable: b
            Using UndecidableInstances might help
        • In the instance declaration for
            ‘MonadBaseControl b (ActionCtxT ctx m)’

    /home/illabout/git/spock/Spock-core/src/Web/Spock/Internal/Wire.hs:279:10: error:
        • Illegal nested type family application ‘StM
                                                    m (StT (ActionCtxT ctx) a)’
          (Use UndecidableInstances to permit this)
        • In the type instance declaration for ‘StM’
          In the instance declaration for
            ‘MonadBaseControl b (ActionCtxT ctx m)’
    ```

    If we heed the warning, we could define specific instances of `MonadBase` and `MonadBaseControl` for `IO`.  It would look something like this:

    ```haskell
    instance MonadBase IO m => MonadBase IO (ActionCtxT ctx m) where
        liftBase = liftBaseDefault

    instance MonadBaseControl IO m => MonadBaseControl IO (ActionCtxT ctx m) where
        type StM (ActionCtxT ctx m) a = ...
        liftBaseWith = ...
        restoreM = ...
    ```

    This means there won't be an instance of `MonadBase` and `MonadBaseControl` for users running `ActionCtxT` in some other base monad (like `ST` or `Maybe`).  But realistically, there probably aren't many users that actually do that.  And even if there are, it's unlikely that they also want to use `liftBase`, `liftBaseWith`, and `restoreM`.

3.  Don't provide `MonadBase` or `MonadBaseControl` instances, but export the constructor for `ActionCtxT`.  That would let users write their own `MonadBase` and `MonadBaseControl` instances.

    We could still provide the `MonadTransControl` instance from commit 0aa24d4, since it doesn't require `UndecidableInstances`.


@agrafix Let me know what you think about these three options.