### PR TITLE
don't remove files that we've put in temporary directories

### DIFF
--- a/Spock-core/Spock-core.cabal
+++ b/Spock-core/Spock-core.cabal
@@ -37,7 +37,6 @@ library
                        case-insensitive >=1.1,
                        containers >=0.5,
                        cookie >=0.4,
-                       directory >=1.2,
                        hashable >=1.2,
                        http-types >=0.8,
                        hvect >= 0.4,

--- a/Spock-core/src/Web/Spock/Internal/Wire.hs
+++ b/Spock-core/src/Web/Spock/Internal/Wire.hs
@@ -361,7 +361,7 @@ middlewareToApp mw =
       notFound = respStateToResponse $ errorResponse status404 "404 - File not found"
 
 makeActionEnvironment ::
-    InternalState -> SpockMethod -> Wai.Request -> IO (RequestInfo (), TVar V.Vault, IO ())
+    InternalState -> SpockMethod -> Wai.Request -> IO (RequestInfo (), TVar V.Vault)
 makeActionEnvironment st stdMethod req =
     do vaultVar <- liftIO $ newTVarIO (Wai.vault req)
        let vaultIf =
@@ -423,18 +423,7 @@ makeActionEnvironment st stdMethod req =
                 , ri_context = ()
                 }
               , vaultVar
-              , removeUploadedFiles (rb_files reqBody)
               )
-
-removeUploadedFiles :: CacheVar (HM.HashMap k UploadedFile) -> IO ()
-removeUploadedFiles uploadedFilesRef =
-    do cvals <- loadCacheVarOpt uploadedFilesRef
-       case cvals of
-         Nothing -> return ()
-         Just uploadedFiles ->
-             forM_ (HM.elems uploadedFiles) $ \uploadedFile ->
-             do stillThere <- doesFileExist (uf_tempLocation uploadedFile)
-                when stillThere $ liftIO $ removeFile (uf_tempLocation uploadedFile)
 
 applyAction :: MonadIO m
             => SpockConfigInternal
@@ -508,7 +497,7 @@ handleRequest' config stdMethod registryLift allActions st coreApp req respond =
            `catch` \(_ :: SizeException) ->
                return (Right $ getErrorHandler config status413)
        case actEnv of
-         Left (mkEnv, vaultVar, cleanUp) ->
+         Left (mkEnv, vaultVar) ->
              do mRespState <-
                     registryLift (applyAction config req mkEnv allActions) `catches`
                       [ Handler $ \(_ :: SizeException) ->
@@ -519,7 +508,6 @@ handleRequest' config stdMethod registryLift allActions st coreApp req respond =
                                ++ ": " ++ show e
                            return $ Just $ getErrorHandler config status500
                       ]
-                cleanUp
                 case mRespState of
                   Just (ResponseHandler responseHandler) ->
                       responseHandler >>= \app -> app req respond

--- a/Spock-core/src/Web/Spock/Internal/Wire.hs
+++ b/Spock-core/src/Web/Spock/Internal/Wire.hs
@@ -46,7 +46,6 @@ import Prelude
 #else
 import Prelude hiding (catch)
 #endif
-import System.Directory
 import System.IO
 import Web.Routing.Router
 import qualified Data.ByteString as BS


### PR DESCRIPTION
Wai's temp file handler already does it (using ResourceT's cleanup). This is causing ResourceT to throw a ResourceClosedException (see below) because it's trying to remove a file that Spock has already removed. In older versions of ResourceT, the "No such file or directory" exception was silently dropped, but this bug has been fixed since version 1.1.11.1 and ResourceT now prints the exception once the request has been handled (after Spock cleans it up). This patch just deletes `removeUploadedFiles` since we don't need to worry about it on our end any more.

The exception:
```
ResourceCleanupException {rceOriginalException = Nothing, rceFirstCleanupException = /tmp/webenc24334-0.buf: removeLink: does not exist (No such file or directory), rceOtherCleanupExceptions = []}
```