### PR TITLE
Restrict upper bound on stm-containers to avoid breaking API changes.

### DIFF
--- a/Spock/Spock.cabal
+++ b/Spock/Spock.cabal
@@ -62,7 +62,7 @@ library
                        resource-pool >=0.2,
                        resourcet >= 0.4,
                        stm >=2.4,
-                       stm-containers >=0.2 && < 1.0,
+                       stm-containers >=0.2 && < 0.3,
                        text >= 0.11.3.1,
                        time >=1.4,
                        transformers >=0.3,

--- a/Spock/Spock.cabal
+++ b/Spock/Spock.cabal
@@ -62,7 +62,7 @@ library
                        resource-pool >=0.2,
                        resourcet >= 0.4,
                        stm >=2.4,
-                       stm-containers >=0.2,
+                       stm-containers >=0.2 && < 1.0,
                        text >= 0.11.3.1,
                        time >=1.4,
                        transformers >=0.3,


### PR DESCRIPTION
stm-containers versions 0.2.* and 1.* differ on module names which is causing Spock to not build. I set the upper bound to 0.3 and that allowed `cabal new-build` to work for me.