### PR TITLE
Remove link to Halcyon

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@ layout: home
       <h4>Easy deployment</h4>
       <p>
         Applications supported by Spock are easily deployed
-        using <a href="https://github.com/commercialhaskell/stack">stack</a>, <a href="https://halcyon.sh/shootout/#hello-spock">Halcyon</a>
+        using <a href="https://github.com/commercialhaskell/stack">stack</a>, 
         or <a href="http://docker.io">Docker</a>
       </p>
     </div>


### PR DESCRIPTION
Halcyon has be unmaintained since 2015 and recently its website has been taken offline too. This might be a good time to remove the link to it.

>  I have not maintained Halcyon and Haskell on Heroku since 2015. I have taken down the websites to avoid misleading people. - *Miëtek Bak, Maintainer of Halcyon on [Twitter](https://twitter.com/mietek/status/1106639304829386752)*