### PR TITLE
Remove redundant import of `Data.Monoid`

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -46,7 +46,6 @@ import Web.Spock.Config
 
 import Control.Monad.Trans
 import Data.IORef
-import Data.Monoid
 import qualified Data.Text as T
 
 data MySession = EmptySession


### PR DESCRIPTION
The code example wouldn't compile because of the redundant import of `Data.Monoid`.