### PR TITLE
Add HTML rendering tutorial to tutorials list

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -9,6 +9,7 @@ permalink: /tutorials/
 - [Getting Started](getting-started)
 - [Building a REST API](rest-api)
 - [Automated Testing](testing)
+- [Rendering HTML with Blaze and Lucid](rendering)
 
 ## Video tutorials
 


### PR DESCRIPTION
The tutorial had been added but was not possible to discover on the
website as it was missing from the tutorials list.

Closes https://github.com/agrafix/Spock/issues/142