### PR TITLE
group file uploads

### DIFF
--- a/Spock-core/src/Web/Spock/Internal/CoreAction.hs
+++ b/Spock-core/src/Web/Spock/Internal/CoreAction.hs
@@ -149,7 +149,7 @@ jsonBody' =
 {-# INLINE jsonBody' #-}
 
 -- | Get uploaded files
-files :: MonadIO m => ActionCtxT ctx m (HM.HashMap T.Text UploadedFile)
+files :: MonadIO m => ActionCtxT ctx m (HM.HashMap T.Text [UploadedFile])
 files =
   do
     b <- asks ri_reqBody

--- a/Spock-core/src/Web/Spock/Internal/Wire.hs
+++ b/Spock-core/src/Web/Spock/Internal/Wire.hs
@@ -142,7 +142,7 @@ loadCacheVar (CacheVar lock makeVal valRef readV) =
 data RequestBody = RequestBody
   { rb_value :: CacheVar BS.ByteString,
     rb_postParams :: CacheVar [(T.Text, T.Text)],
-    rb_files :: CacheVar (HM.HashMap T.Text UploadedFile)
+    rb_files :: CacheVar (HM.HashMap T.Text [UploadedFile])
   }
 
 data RequestInfo ctx = RequestInfo
@@ -418,13 +418,13 @@ makeActionEnvironment st stdMethod req =
               (bodyParams, bodyFiles) <-
                 P.sinkRequestBody (P.tempFileBackEnd st) rbt loader
               let uploadedFiles =
-                    HM.fromList $
+                    HM.fromListWith (<>) $
                       flip map bodyFiles $ \(k, fileInfo) ->
                         ( T.decodeUtf8 k,
-                          UploadedFile
+                          [UploadedFile
                             (T.decodeUtf8 $ P.fileName fileInfo)
                             (T.decodeUtf8 $ P.fileContentType fileInfo)
-                            (P.fileContent fileInfo)
+                            (P.fileContent fileInfo)]
                         )
                   postParams =
                     map (T.decodeUtf8 *** T.decodeUtf8) bodyParams

--- a/Spock-core/test/Web/Spock/SafeSpec.hs
+++ b/Spock-core/test/Web/Spock/SafeSpec.hs
@@ -22,6 +22,7 @@ import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSLC
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.HashMap.Strict as HM
 import GHC.Generics
 import Network.HTTP.Types.Status
 import qualified Network.Wai as Wai
@@ -114,6 +115,15 @@ app =
     hookAnyCustom "MYVERB" $ text . T.intercalate "/"
     get ("wai" <//> wildcard) $ \_ ->
       respondApp dummyWai
+    post "file/upload" $
+      do
+        f <- files
+        text (T.pack $ show $ HM.size f)
+    post "file/upload/multi" $
+      do
+        f <- files
+        let uploadFiles = f HM.! "file"
+        text (T.pack $ show $ length $ uploadFiles)
 
 dummyWai :: Wai.Application
 dummyWai req respond =


### PR DESCRIPTION
This fix allows uploads with similar names, i.e.
```
<input multiple type="file" name="pictures" />
```

Fixes: #143 

However... File uploads will always be grouped
regardless if the form uploads a single file or
multiple files. So it will break any code using
file uploads. (Probably create a new version??)