### PR TITLE
make spock compile with ghc-9.6

### DIFF
--- a/Spock-core/src/Web/Spock/Core.hs
+++ b/Spock-core/src/Web/Spock/Core.hs
@@ -69,6 +69,7 @@ where
 
 import Control.Applicative
 import Control.Monad.Reader
+import Data.Foldable (forM_)
 import Data.HVect hiding (head)
 import qualified Data.Text as T
 import qualified Network.HTTP.Types as Http


### PR DESCRIPTION
`Control.Monad.Reader` from mtl-2.3.1, which is now distributed with ghc 9.6, not longer exports `Control.Monad`, so `forM_` is not available.